### PR TITLE
Upgraded the version of Actions being used

### DIFF
--- a/.github/workflows/pull-request-jobs.yml
+++ b/.github/workflows/pull-request-jobs.yml
@@ -16,16 +16,16 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '11'
       - name: Run Unit Tests
         run: ./gradlew :app:testDebugUnitTest --tests "org.fnives.tiktokdownloader.*"
       - name: Upload Test Results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test Results

--- a/.github/workflows/up-to-date-jobs.yml
+++ b/.github/workflows/up-to-date-jobs.yml
@@ -16,16 +16,16 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '11'
       - name: Run Up-To-Date Tests
         run: ./gradlew :app:testDebugUnitTest --tests "org.fnives.uptodate.*"
       - name: Upload Test Results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test Results


### PR DESCRIPTION
Hi @fknives , the warnings you are currently seeing #18  in GitHub actions is because we are using a very old version of those actions and they have been depreciated.

In this commit, I have upgraded the versions of those actions to their current stable release and have also tested it. Please review it and merge it if it solves the issue.

Thanks

Fixes #18 